### PR TITLE
Fix send button text wrapping

### DIFF
--- a/src/ApiRequestEditor.js
+++ b/src/ApiRequestEditor.js
@@ -77,6 +77,7 @@ export class ApiRequestEditor extends AmfHelperMixin(EventsTargetMixin(LitElemen
       .action-bar {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
         align-items: center;
         margin-top: 8px;
       }
@@ -91,6 +92,10 @@ export class ApiRequestEditor extends AmfHelperMixin(EventsTargetMixin(LitElemen
         flex: 1;
       }
 
+      .send-button {
+        white-space: nowrap;
+      }
+      
       .section-title {
         margin: 0.83em 8px;
         letter-spacing: 0.1rem;


### PR DESCRIPTION
This PR fixes css styling to correctly wrap text in the send button.

Before:
![image](https://user-images.githubusercontent.com/24916481/68507866-a9098e80-024b-11ea-9ed2-764a0bb956ae.png)

After:
![image](https://user-images.githubusercontent.com/24916481/68507883-b292f680-024b-11ea-9a1e-f278412190e7.png)
