### PR TITLE
fix(server): pass selected into server selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -805,19 +805,18 @@
       }
     },
     "@api-components/api-server-selector": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.4.0.tgz",
-      "integrity": "sha512-64q92LJjGbr2eiPEn+BbniuzSqNDzJO1g/MVXbXBmDCbcg4Qzgt3hMf1tYp7hg0P5Wb19Tl4ssLAzkyvC70qvA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.5.0.tgz",
+      "integrity": "sha512-7gUqe+7LxniKvk/DnpsnTPvqchG9dhB0u0IIlrP1dd7NHiQmoRTgwCzyNRljpm/GWPgBuRYo7JD4QI5rR7Oj/Q==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.5",
-        "@advanced-rest-client/events-target-mixin": "^3.1.1",
         "@anypoint-web-components/anypoint-button": "^1.0.15",
         "@anypoint-web-components/anypoint-dropdown": "^1.0.1",
         "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.14",
         "@anypoint-web-components/anypoint-input": "^0.2.14",
         "@anypoint-web-components/anypoint-item": "^1.0.5",
         "@anypoint-web-components/anypoint-listbox": "^1.0.4",
-        "@api-components/amf-helper-mixin": "^4.0.26",
+        "@api-components/amf-helper-mixin": "^4.1.1",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@api-components/api-body-editor": "^4.0.4",
     "@api-components/api-form-mixin": "^3.1.0",
     "@api-components/api-headers-editor": "^4.1.0",
-    "@api-components/api-server-selector": "^0.4.0",
+    "@api-components/api-server-selector": "^0.5.0",
     "@api-components/api-url-data-model": "^5.0.1",
     "@api-components/api-url-editor": "^4.0.3",
     "@api-components/api-url-params-editor": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request-editor",
   "description": "A request editor that builds the UI based on AMF model",
-  "version": "5.0.2",
+  "version": "5.0.1",
   "license": "Apache-2.0",
   "main": "api-request-editor.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-request-editor",
   "description": "A request editor that builds the UI based on AMF model",
-  "version": "5.0.1",
+  "version": "5.0.3",
   "license": "Apache-2.0",
   "main": "api-request-editor.js",
   "keywords": [

--- a/src/ApiRequestEditor.js
+++ b/src/ApiRequestEditor.js
@@ -1353,7 +1353,8 @@ export class ApiRequestEditor extends HeadersParserMixin(AmfHelperMixin(EventsTa
       allowCustomBaseUri,
       outlined,
       compatibility,
-      _serverSelectorHidden
+      _serverSelectorHidden,
+      selected,
     } = this;
     return html`
     <api-server-selector
@@ -1362,6 +1363,7 @@ export class ApiRequestEditor extends HeadersParserMixin(AmfHelperMixin(EventsTa
       .amf="${amf}"
       .value="${serverValue}"
       .type="${serverType}"
+      .selectedValue="${selected}"
       autoselect
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"

--- a/src/ApiRequestEditor.js
+++ b/src/ApiRequestEditor.js
@@ -1346,7 +1346,7 @@ export class ApiRequestEditor extends HeadersParserMixin(AmfHelperMixin(EventsTa
       .value="${serverValue}"
       .type="${serverType}"
       .selectedShape="${selected}"
-      .selectedShapeType="${'method'}"
+      selectedShapeType="method"
       autoselect
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"

--- a/src/ApiRequestEditor.js
+++ b/src/ApiRequestEditor.js
@@ -1363,7 +1363,8 @@ export class ApiRequestEditor extends HeadersParserMixin(AmfHelperMixin(EventsTa
       .amf="${amf}"
       .value="${serverValue}"
       .type="${serverType}"
-      .selectedValue="${selected}"
+      .selectedShape="${selected}"
+      .selectedShapeType="method"
       autoselect
       ?compatibility="${compatibility}"
       ?outlined="${outlined}"


### PR DESCRIPTION
Change behavior of editor.

- No longer listen for navigation events
- Instead, pass in `selected` value to the server selector's `selectedShape`, and `'method'` to its `selectedShapeType`
- Update servers on amfChange and on `selected` change